### PR TITLE
refactor user create

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -24,3 +24,6 @@ config :argon2_elixir, t_cost: 2, m_cost: 8
 
 # Configures mailer for testing
 config :forks_the_egg_sample, ForksTheEggSampleWeb.Mailer, adapter: Bamboo.TestAdapter
+
+# Suppress log warming in test
+config :phauxth, log_level: :error

--- a/lib/forks_the_egg_sample_web/controllers/user_controller.ex
+++ b/lib/forks_the_egg_sample_web/controllers/user_controller.ex
@@ -21,12 +21,11 @@ defmodule ForksTheEggSampleWeb.UserController do
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(conn, %{"user" => %{"email" => email} = user_params}) do
-    key = Token.sign(%{"email" => email})
-
+  def create(conn, %{"user" => user_params}) do
     case Accounts.create_user(user_params) do
-      {:ok, user} ->
+      {:ok, %User{email: email} = user} ->
         Log.info(%Log{user: user.id, message: "user created"})
+        key = Token.sign(%{"email" => email})
         Email.confirm_request(email, key)
 
         conn


### PR DESCRIPTION
I wanted to make sure we had not been using params before ecto schema had a chance to validate them. 

By moving the `Token.sign` in to the `Accounts.create_user` block we address three issues. 
* We only sign a key given we have a valid user. 
* We don't directly rely on unsanitized params
* We loosen our pattern match on the function so that it can fail correctly given params are missing. 